### PR TITLE
2946: Runtypes issue and correct zip

### DIFF
--- a/lambdas/buildspec.yml
+++ b/lambdas/buildspec.yml
@@ -11,28 +11,28 @@ phases:
       - make lambdas
       - cd lambdas
       - cd authorizer
-      - zip ../authorizer.zip index.js package.json node_modules/**/*
+      - zip -r ../authorizer.zip index.js package.json node_modules/
       - cd ..
       - cd create-job
-      - zip ../create-job.zip index.js package.json node_modules/**/*
+      - zip -r ../create-job.zip index.js package.json node_modules/
       - cd ..
       - cd create-zip
-      - zip ../create-zip.zip index.js package.json node_modules/**/*
+      - zip -r ../create-zip.zip index.js package.json node_modules/
       - cd ..
       - cd format-chunk
-      - zip ../format-chunk.zip index.js package.json node_modules/**/*
+      - zip -r ../format-chunk.zip index.js package.json node_modules/
       - cd ..
       - cd get-input-files
-      - zip ../get-input-files.zip index.js package.json node_modules/**/*
+      - zip -r ../get-input-files.zip index.js package.json node_modules/
       - cd ..
       - cd get-job
-      - zip ../get-job.zip index.js package.json node_modules/**/*
+      - zip -r ../get-job.zip index.js package.json node_modules/
       - cd ..
       - cd start-job
-      - zip ../start-job.zip index.js dynamodb.js package.json node_modules/**/*
+      - zip -r ../start-job.zip index.js dynamodb.js package.json node_modules/
       - cd ..
       - cd transcode
-      - zip ../transcode.zip index.js package.json node_modules/**/*
+      - zip -r ../transcode.zip index.js package.json node_modules/
       - cd ..
   post_build:
     commands:

--- a/lambdas/create-job/index.ts
+++ b/lambdas/create-job/index.ts
@@ -42,7 +42,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     if (!result.success) {
       return {
         statusCode: 400,
-        body: `${result.message} (Event: ${event.body})`,
+        body: `${result.message}`,
       };
     }
     assert(TABLE_NAME, "Missing TABLE_NAME");

--- a/lambdas/create-job/index.ts
+++ b/lambdas/create-job/index.ts
@@ -42,7 +42,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     if (!result.success) {
       return {
         statusCode: 400,
-        body: `${result.message} (Key: ${result.key})`,
+        body: `${result.message} (Event: ${event.body})`,
       };
     }
     assert(TABLE_NAME, "Missing TABLE_NAME");

--- a/lambdas/create-job/package-lock.json
+++ b/lambdas/create-job/package-lock.json
@@ -11,7 +11,7 @@
         "@types/aws-lambda": "^8.10.152",
         "@types/node": "^22.0.0",
         "@types/uuid": "^8.3.0",
-        "runtypes": "^5.2.0",
+        "runtypes": "6.7.0",
         "typescript": "^5.9.2",
         "uuid": "^8.3.2"
       }
@@ -146,6 +146,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.914.0.tgz",
       "integrity": "sha512-KPjCKzihG5FsSN5rGn1lo4o07RBziBYu1ztQkPQd2zHL//srveZ8OSBXZitBvKFcoXLr70GFQPEVwTSIG0WuXg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1376,10 +1377,9 @@
       "license": "MIT"
     },
     "node_modules/runtypes": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-5.2.0.tgz",
-      "integrity": "sha512-ArcmkYvNWkHrwg4Ic7St365oUGAkiIcs6vNmoRNzADv7nBhrTQC8C562TYnIV9nxxMxdmAAHsehD78xuWeYPJA==",
-      "deprecated": "this version contains a breaking change, see https://github.com/pelotom/runtypes/issues/206",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.7.0.tgz",
+      "integrity": "sha512-3TLdfFX8YHNFOhwHrSJza6uxVBmBrEjnNQlNXvXCdItS0Pdskfg5vVXUTWIN+Y23QR09jWpSl99UHkA83m4uWA==",
       "license": "MIT"
     },
     "node_modules/strnum": {

--- a/lambdas/create-job/package.json
+++ b/lambdas/create-job/package.json
@@ -14,7 +14,7 @@
     "@types/aws-lambda": "^8.10.152",
     "@types/node": "^22.0.0",
     "@types/uuid": "^8.3.0",
-    "runtypes": "^5.2.0",
+    "runtypes": "6.7.0",
     "typescript": "^5.9.2",
     "uuid": "^8.3.2"
   }

--- a/lambdas/create-zip/package-lock.json
+++ b/lambdas/create-zip/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^22.0.0",
         "archiver": "^5.3.0",
         "p-limit": "^3.1.0",
-        "runtypes": "^6.3.0",
+        "runtypes": "6.7.0",
         "typescript": "^5.9.2"
       }
     },
@@ -224,6 +224,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.914.0.tgz",
       "integrity": "sha512-ZW0ALyys+pTpPvDyKp1InkfUGqttezH9c4TNxwuRKE1M78fwFf/Fnwrdmxzgc9SXReyANB4zpLHtbrTk4mj4Rg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",

--- a/lambdas/create-zip/package.json
+++ b/lambdas/create-zip/package.json
@@ -19,7 +19,7 @@
     "@types/archiver": "^5.1.0",
     "archiver": "^5.3.0",
     "p-limit": "^3.1.0",
-    "runtypes": "^6.3.0",
+    "runtypes": "6.7.0",
     "@tsconfig/node22": "^22.0.0",
     "@types/aws-lambda": "^8.10.152",
     "@types/node": "^22.0.0",

--- a/lambdas/format-chunk/index.ts
+++ b/lambdas/format-chunk/index.ts
@@ -51,10 +51,10 @@ export const handler: Handler = async (event) => {
   const result = Job.validate(event);
   if (!result.success) {
     console.error(
-      `Record failed validation: ${result.message} (Key: ${result.key}) (Event: ${event})`
+      `Record failed validation: ${result.message} (Event: ${event})`
     );
     throw new Error(
-      `Record failed validation: ${result.message} (Key: ${result.key}) (Event: ${event})`
+      `Record failed validation: ${result.message} (Event: ${event})`
     );
   }
   const job = result.value;

--- a/lambdas/format-chunk/package-lock.json
+++ b/lambdas/format-chunk/package-lock.json
@@ -11,7 +11,7 @@
         "@tsconfig/node22": "^22.0.0",
         "@types/aws-lambda": "^8.10.152",
         "@types/node": "^22.0.0",
-        "runtypes": "^5.2.0",
+        "runtypes": "6.7.0",
         "typescript": "^5.9.2"
       }
     },
@@ -222,6 +222,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.914.0.tgz",
       "integrity": "sha512-KPjCKzihG5FsSN5rGn1lo4o07RBziBYu1ztQkPQd2zHL//srveZ8OSBXZitBvKFcoXLr70GFQPEVwTSIG0WuXg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1791,10 +1792,9 @@
       "license": "MIT"
     },
     "node_modules/runtypes": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-5.2.0.tgz",
-      "integrity": "sha512-ArcmkYvNWkHrwg4Ic7St365oUGAkiIcs6vNmoRNzADv7nBhrTQC8C562TYnIV9nxxMxdmAAHsehD78xuWeYPJA==",
-      "deprecated": "this version contains a breaking change, see https://github.com/pelotom/runtypes/issues/206",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.7.0.tgz",
+      "integrity": "sha512-3TLdfFX8YHNFOhwHrSJza6uxVBmBrEjnNQlNXvXCdItS0Pdskfg5vVXUTWIN+Y23QR09jWpSl99UHkA83m4uWA==",
       "license": "MIT"
     },
     "node_modules/strnum": {

--- a/lambdas/format-chunk/package.json
+++ b/lambdas/format-chunk/package.json
@@ -13,7 +13,7 @@
     "@aws-sdk/client-dynamodb": "^3.10.0",
     "@aws-sdk/client-s3": "^3.10.0",
     "@aws-sdk/lib-dynamodb": "^3.10.0",
-    "runtypes": "^5.2.0",
+    "runtypes": "6.7.0",
     "@tsconfig/node22": "^22.0.0",
     "@types/aws-lambda": "^8.10.152",
     "@types/node": "^22.0.0",

--- a/lambdas/get-input-files/index.ts
+++ b/lambdas/get-input-files/index.ts
@@ -45,10 +45,10 @@ export const handler: Handler = async (event) => {
   const result = Job.validate(event);
   if (!result.success) {
     console.error(
-      `Record failed validation: ${result.message} (Key: ${result.key}) (Event: ${event})`
+      `Record failed validation: ${result.message} (Event: ${event})`
     );
     throw new Error(
-      `Record failed validation: ${result.message} (Key: ${result.key}) (Event: ${event})`
+      `Record failed validation: ${result.message} (Event: ${event})`
     );
   }
   const job = result.value;

--- a/lambdas/get-input-files/package-lock.json
+++ b/lambdas/get-input-files/package-lock.json
@@ -11,7 +11,7 @@
         "@tsconfig/node22": "^22.0.0",
         "@types/aws-lambda": "^8.10.152",
         "@types/node": "^22.0.0",
-        "runtypes": "^5.2.0",
+        "runtypes": "6.7.0",
         "typescript": "^5.9.2"
       }
     },
@@ -222,6 +222,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.914.0.tgz",
       "integrity": "sha512-KPjCKzihG5FsSN5rGn1lo4o07RBziBYu1ztQkPQd2zHL//srveZ8OSBXZitBvKFcoXLr70GFQPEVwTSIG0WuXg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1791,10 +1792,9 @@
       "license": "MIT"
     },
     "node_modules/runtypes": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-5.2.0.tgz",
-      "integrity": "sha512-ArcmkYvNWkHrwg4Ic7St365oUGAkiIcs6vNmoRNzADv7nBhrTQC8C562TYnIV9nxxMxdmAAHsehD78xuWeYPJA==",
-      "deprecated": "this version contains a breaking change, see https://github.com/pelotom/runtypes/issues/206",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.7.0.tgz",
+      "integrity": "sha512-3TLdfFX8YHNFOhwHrSJza6uxVBmBrEjnNQlNXvXCdItS0Pdskfg5vVXUTWIN+Y23QR09jWpSl99UHkA83m4uWA==",
       "license": "MIT"
     },
     "node_modules/strnum": {

--- a/lambdas/get-input-files/package.json
+++ b/lambdas/get-input-files/package.json
@@ -13,7 +13,7 @@
     "@aws-sdk/client-dynamodb": "^3.10.0",
     "@aws-sdk/client-s3": "^3.10.0",
     "@aws-sdk/lib-dynamodb": "^3.10.0",
-    "runtypes": "^5.2.0",
+    "runtypes": "6.7.0",
     "@tsconfig/node22": "^22.0.0",
     "@types/aws-lambda": "^8.10.152",
     "@types/node": "^22.0.0",

--- a/lambdas/get-job/package-lock.json
+++ b/lambdas/get-job/package-lock.json
@@ -143,6 +143,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.914.0.tgz",
       "integrity": "sha512-KPjCKzihG5FsSN5rGn1lo4o07RBziBYu1ztQkPQd2zHL//srveZ8OSBXZitBvKFcoXLr70GFQPEVwTSIG0WuXg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",

--- a/lambdas/start-job/index.ts
+++ b/lambdas/start-job/index.ts
@@ -54,7 +54,7 @@ export const handler: DynamoDBStreamHandler = async (event) => {
       const result = Job.validate(data);
       if (!result.success) {
         console.error(
-          `Record failed validation: ${result.message} (Key: ${result.key}) (Data: ${data})`
+          `Record failed validation: ${result.message} (Data: ${data})`
         );
         continue;
       }

--- a/lambdas/start-job/package-lock.json
+++ b/lambdas/start-job/package-lock.json
@@ -12,7 +12,7 @@
         "@tsconfig/node22": "^22.0.0",
         "@types/aws-lambda": "^8.10.152",
         "@types/node": "^22.0.0",
-        "runtypes": "^5.2.0",
+        "runtypes": "6.7.0",
         "typescript": "^5.9.2"
       }
     },
@@ -146,6 +146,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.914.0.tgz",
       "integrity": "sha512-KPjCKzihG5FsSN5rGn1lo4o07RBziBYu1ztQkPQd2zHL//srveZ8OSBXZitBvKFcoXLr70GFQPEVwTSIG0WuXg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1421,10 +1422,9 @@
       "license": "MIT"
     },
     "node_modules/runtypes": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-5.2.0.tgz",
-      "integrity": "sha512-ArcmkYvNWkHrwg4Ic7St365oUGAkiIcs6vNmoRNzADv7nBhrTQC8C562TYnIV9nxxMxdmAAHsehD78xuWeYPJA==",
-      "deprecated": "this version contains a breaking change, see https://github.com/pelotom/runtypes/issues/206",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.7.0.tgz",
+      "integrity": "sha512-3TLdfFX8YHNFOhwHrSJza6uxVBmBrEjnNQlNXvXCdItS0Pdskfg5vVXUTWIN+Y23QR09jWpSl99UHkA83m4uWA==",
       "license": "MIT"
     },
     "node_modules/strnum": {

--- a/lambdas/start-job/package.json
+++ b/lambdas/start-job/package.json
@@ -16,7 +16,7 @@
     "@aws-sdk/client-sfn": "^3.10.0",
     "@aws-sdk/lib-dynamodb": "^3.10.0",
     "@aws-sdk/util-dynamodb": "^3.10.0",
-    "runtypes": "^5.2.0",
+    "runtypes": "6.7.0",
     "@tsconfig/node22": "^22.0.0",
     "@types/aws-lambda": "^8.10.152",
     "@types/node": "^22.0.0",

--- a/lambdas/transcode/package-lock.json
+++ b/lambdas/transcode/package-lock.json
@@ -222,6 +222,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.896.0.tgz",
       "integrity": "sha512-f52lWRtrcG7IMS3wAGOOkq5Ra4rhqu9VlAnMn8wwsvKz2WmCYDvxQTuTpaIXuvTeMGVVhBT4lUR1aRtzBHxSHw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -275,6 +276,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.896.0.tgz",
       "integrity": "sha512-UETVuMLQRqgrWxTnavotY0TlB/jaR9sL3hkIFPx4KtjmigNBdwRaiVfOuTnIXKd+w9RPINYG//nnrK+5gIyZkA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -2133,6 +2135,7 @@
       "version": "3.896.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.896.0.tgz",
       "integrity": "sha512-f52lWRtrcG7IMS3wAGOOkq5Ra4rhqu9VlAnMn8wwsvKz2WmCYDvxQTuTpaIXuvTeMGVVhBT4lUR1aRtzBHxSHw==",
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2182,6 +2185,7 @@
       "version": "3.896.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.896.0.tgz",
       "integrity": "sha512-UETVuMLQRqgrWxTnavotY0TlB/jaR9sL3hkIFPx4KtjmigNBdwRaiVfOuTnIXKd+w9RPINYG//nnrK+5gIyZkA==",
+      "peer": true,
       "requires": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",


### PR DESCRIPTION
## Description

Update the runtypes package to use [version 6.7.0](https://www.npmjs.com/package/runtypes/v/6.7.0), which is the last available version that fully supports CommonJS modules. The newer versions support ESM modules, but these aren't compatible with the [Lambda environment by default](https://docs.aws.amazon.com/lambda/latest/dg/lambda-nodejs.html).

Also zip the files correctly so all node_modules are included