### PR TITLE
Format-chunk keyscount field is optional

### DIFF
--- a/lambdas/format-chunk/event.json
+++ b/lambdas/format-chunk/event.json
@@ -13,7 +13,6 @@
   ],
   "id": "job-1234",
   "status": "PENDING",
-  "keyscount": 2,
   "input": {
     "bucket": "input-bucket",
     "key": "input/video/source.mp4"

--- a/lambdas/format-chunk/index.ts
+++ b/lambdas/format-chunk/index.ts
@@ -1,6 +1,6 @@
 import { S3, paginateListObjectsV2 } from "@aws-sdk/client-s3";
 import { Handler } from "aws-lambda";
-import { Array, Literal, Number, Record, String, Union } from "runtypes";
+import { Array, Literal, Number, Optional, Record, String, Union } from "runtypes";
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 import assert from "assert";
@@ -21,7 +21,7 @@ const Job = Record({
   })),
   id: String,
   status: Union(Literal("PENDING")),
-  keyscount: Number,
+  keyscount: Optional(Number),
   input: Record({
     bucket: String,
     key: String,


### PR DESCRIPTION
## Description

Make the `keyscount` field optional on the `format-chunk` lambda.