### PR TITLE
2946: Format chunk output bucket

### DIFF
--- a/lambdas/format-chunk/event.json
+++ b/lambdas/format-chunk/event.json
@@ -3,12 +3,12 @@
     {
       "index": 0,
       "key": "input/video/chunk0.mp4",
-      "format": "xxx"
+      "format": "output/video/chunk0.mp4|mp4|aac|1000000|output-bucket"
     },
     {
       "index": 1,
       "key": "input/video/chunk1.mp4",
-      "format": "xxx"
+      "format": "output/video/chunk1.mp4|mp4|aac|1000000|output-bucket"
     }
   ],
   "id": "job-1234",

--- a/lambdas/format-chunk/index.ts
+++ b/lambdas/format-chunk/index.ts
@@ -66,7 +66,7 @@ export const handler: Handler = async (event) => {
   for (const { key, index, format } of job.chunk) {
     const formatInfo = format.split("|");
     let out_key = formatInfo[0]
-    let output = {"container": formatInfo[1], "codec": formatInfo[2], "bitrate": formatInfo[3] }
+    let output = {"container": formatInfo[1], "codec": formatInfo[2], "bitrate": formatInfo[3], "bucket": formatInfo[4]};
       const basename = path.parse(key).name;
       const ext = {
         mp3: "mp3",
@@ -83,7 +83,7 @@ export const handler: Handler = async (event) => {
           key,
         },
         output: {
-          bucket: job.output[0],
+          bucket: output.bucket,
           key:  outputKey,
           container: formatInfo[1],
           codec: formatInfo[2],
@@ -95,7 +95,7 @@ export const handler: Handler = async (event) => {
 
   for (const file of files) {
     if (isLocal) {
-      console.log(`Local mode: Mocking DynamoDB update for file ${file.index}`);
+      console.log(`Local mode: Mocking DynamoDB update for file ${file.index} with value: ${JSON.stringify(file)}`);
     } else {
       await dynamo.update({
         TableName: TABLE_NAME,

--- a/lambdas/get-input-files/index.ts
+++ b/lambdas/get-input-files/index.ts
@@ -85,7 +85,7 @@ export const handler: Handler = async (event) => {
   for (let j= 0; j<keyslen; j++) {
     let key = keys[j]
     for (let i = 0; i < outputLen; i++) {
-      let format = [ output[i].key, output[i].container,  output[i].codec,  output[i].bitrate].join("|")
+      let format = [output[i].key, output[i].container,  output[i].codec,  output[i].bitrate, output[i].bucket].join("|")
       fanout[index] = {key, index, format, fanoutTotal}
       index++   
     }


### PR DESCRIPTION
## Description

Set the correct output bucket in the format field in `get-input-files`, so `format-chunk` uses the proper bucket.